### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/config.json
+++ b/config.json
@@ -6,8 +6,8 @@
         "labeling"
     ],
     "description": "Assign tags to images using example images",
-    "docker_image": "supervisely/labeling:6.73.506",
-    "instance_version": "6.15.40",
+    "docker_image": "supervisely/labeling:6.73.564",
+    "instance_version": "6.15.60",
     "main_script": "src/main.py",
     "gui_template": "src/gui.html",
     "task_location": "application_sessions",

--- a/config.json
+++ b/config.json
@@ -1,32 +1,32 @@
 {
-    "name": "Visual Tagging",
-    "type": "app",
-    "categories": [
-        "images",
-        "labeling"
-    ],
-    "description": "Assign tags to images using example images",
-    "docker_image": "supervisely/labeling:6.73.564",
-    "instance_version": "6.15.60",
-    "main_script": "src/main.py",
-    "gui_template": "src/gui.html",
-    "task_location": "application_sessions",
-    "isolate": true,
-    "integrated_into": [
-        "image_annotation_tool"
-    ],
-    "icon": "https://img.icons8.com/color/100/000000/medium-icons.png",
-    "icon_background": "#FFFFFF",
-    "context_menu": {
-        "target": [
-            "images_project"
-        ]
-    },
-    "hotkeys": [
-        {
-            "hotkey": "alt+t",
-            "command": "assign_tag"
-        }
-    ],
-    "poster": "https://user-images.githubusercontent.com/48245050/182596826-d09bdcba-6021-4b93-a5f5-0b77804a3669.png"
+  "name": "Visual Tagging",
+  "type": "app",
+  "categories": [
+    "images",
+    "labeling"
+  ],
+  "description": "Assign tags to images using example images",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "instance_version": "6.15.60",
+  "main_script": "src/main.py",
+  "gui_template": "src/gui.html",
+  "task_location": "application_sessions",
+  "isolate": true,
+  "integrated_into": [
+    "image_annotation_tool"
+  ],
+  "icon": "https://img.icons8.com/color/100/000000/medium-icons.png",
+  "icon_background": "#FFFFFF",
+  "context_menu": {
+    "target": [
+      "images_project"
+    ]
+  },
+  "hotkeys": [
+    {
+      "hotkey": "alt+t",
+      "command": "assign_tag"
+    }
+  ],
+  "poster": "https://user-images.githubusercontent.com/48245050/182596826-d09bdcba-6021-4b93-a5f5-0b77804a3669.png"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,1 @@
-supervisely==6.73.506
+supervisely==6.73.564


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Updates `instance_version` in app config files.
- Does not release applications.

Validation: generated ecosystem inventory report.
